### PR TITLE
7-error-response-handler

### DIFF
--- a/includes/Cluster.hpp
+++ b/includes/Cluster.hpp
@@ -14,6 +14,7 @@
 #include "Request.hpp"
 #include "VirtualServer.hpp"
 #include <algorithm>
+#include "utils.hpp"
 
 enum FDType{
 	FD_LISTENER,	// Listening socket: accepts new incoming connections
@@ -57,6 +58,9 @@ class Cluster {
 		void removeFD(int fd);
 		void updateActivity(int fd);
 		void handleTimeout();
+
+		// Response
+		Response generateErrorResponse(int code, int config_index);
 
 		std::vector<VirtualServer>	_servers;
 		std::vector<ServerConfig>	_config_data;

--- a/includes/Response.hpp
+++ b/includes/Response.hpp
@@ -20,16 +20,22 @@ private:
 	const static std::map<int, std::string>	_status_messages;
 	static std::map<int, std::string>	_initStatusMessages();
 
+	std::string	build();
+	void		prepare();
+
+
 public:
 	Response();
 	~Response();
 	void setStatusCode(int code);
 	void setBody(const std::string &body);
 	void addHeader(const std::string &key, const std::string &value);
-	std::string build();
 
-	void	prepare();
 	int		sendResponse(int fd);
+
+	static std::string	getStatusMessage(int code);
+	void				makeDefaultError(int code);
+
 };
 
 #endif

--- a/includes/utils.hpp
+++ b/includes/utils.hpp
@@ -1,4 +1,9 @@
 #ifndef UTILS_HPP
 # define UTILS_HPP
 
+#include <filesystem>
+#include <fstream>
+
+std::string	loadFile(const std::string &path);
+
 #endif

--- a/srcs/core/Cluster.cpp
+++ b/srcs/core/Cluster.cpp
@@ -279,3 +279,22 @@ void Cluster::handleTimeout()
 		}
 	}
 }
+
+Response Cluster::generateErrorResponse(int code, int config_index) {
+	Response res;
+	const ServerConfig& config = _config_data[config_index];
+
+	if (config.error_pages.count(code)) {
+		std::string path = config.error_pages.at(code);
+		std::string custom_body = loadFile(path);
+		if (!custom_body.empty()) {
+			res.setStatusCode(code);
+			res.setBody(custom_body);
+			res.addHeader("Content-Type", "text/html");
+			return res;
+		}
+	}
+
+	res.makeDefaultError(code);
+	return res;
+}

--- a/srcs/logic/Response.cpp
+++ b/srcs/logic/Response.cpp
@@ -69,3 +69,18 @@ int		Response::sendResponse(int fd){
 		return 1;
 	return 0;
 }
+
+std::string	Response::getStatusMessage(int code){
+	if (_status_messages.count(code))
+		return _status_messages.at(code);
+	return "Unknown Error";
+}
+
+void Response::makeDefaultError(int code) {
+	_status_code = code;
+	std::string msg = getStatusMessage(code);
+	_body = "<html><head><title>" + std::to_string(code) + " " + msg + "</title></head>"
+			"<body><center><h1>" + std::to_string(code) + " " + msg + "</h1></center>"
+			"<hr><center>Webslave/1.0</center></body></html>";
+	addHeader("Content-Type", "text/html");
+}

--- a/srcs/utils.cpp
+++ b/srcs/utils.cpp
@@ -1,1 +1,10 @@
 #include "utils.hpp"
+
+std::string	loadFile(const std::string &path){
+	std::ifstream file(path.c_str());
+	if (!file.is_open())
+		return "";
+	std::stringstream buffer;
+	buffer << file.rdbuf();
+	return buffer.str();
+}


### PR DESCRIPTION
This PR implements the error handling subsystem and enhances the **Response** class to support automated error page generation. The system now distinguishes between custom error pages defined in the configuration and fallback default pages generated by the server.

**Response Class Enhancements**

- **makeDefaultError(int code)**: Generates a standard HTML error template when no custom page is provided.

- **getStatusMessage(int code)**: Provides RFC-compliant reason phrases for HTTP status codes.

- **loadErrorFile(string path):** Utility to read external HTML files into the response body.

- Dynamic Content-Length: The **build()** method now automatically calculates and adds the **Content-Length** header for error pages and bodies.

**Cluster Logic Integration**

- **generateErrorResponse(int code, int config_index):**

    - Acts as the bridge between **ServerConfig** and the **Response** builder.

    - Checks for the **error_page** directive in the configuration.

    - Implements a fallback mechanism: **Custom Page -> Default HTML Template**.
    
    Closes #7 