### PR TITLE
Feature/11 redirections

### DIFF
--- a/srcs/logic/Methods.cpp
+++ b/srcs/logic/Methods.cpp
@@ -114,6 +114,15 @@ Response RequestHandler::handleRequest(Request &req, const ServerConfig &config)
 		res.setStatusCode(404);
 		return res;
 	}
+
+	if (!loc->redirection.second.empty()){
+		int code = loc->redirection.first;
+		res.setStatusCode(code ? code : 302);
+		res.addHeader("Location", loc->redirection.second);
+		res.setBody("Redirecting to " + loc->redirection.second);
+		return res;
+	}
+
 	bool allowed_method = false;
 	for (size_t i = 0; i < loc->methods.size(); i++) {
 		if (loc->methods[i] == req.getMethod()) {
@@ -138,7 +147,7 @@ Response RequestHandler::handleRequest(Request &req, const ServerConfig &config)
 
 	bool keep_alive = req.shouldKeepAlive();
 	res.setConnectionHeader(keep_alive);
-	
+
 	return res;
 }
 

--- a/srcs/logic/Response.cpp
+++ b/srcs/logic/Response.cpp
@@ -24,6 +24,9 @@ std::map<int, std::string>	Response::_initStatusMessages(){
 	m[200] = "OK";
 	m[201] = "Created";
 	m[301] = "Moved Permanently";
+	m[302] = "Found";
+	m[307] = "Temporary Redirect";
+	m[308] = "Permanent Redirect";
 	m[400] = "Bad Request";
 	m[403] = "Forbidden";
 	m[404] = "Not Found";


### PR DESCRIPTION
This PR adds support for HTTP redirections configured directly in the `default.conf` file. It allows the server to redirect requests to both internal paths and external URLs without accessing the filesystem.

**Key Changes**

- **Config Parser**: Added support for the `return` directive within `location` blocks.

   - Syntax: `return [status_code] [target_url];`

- **Request Handling:**

    - Implemented a high-priority check in `RequestHandler::handleRequest` that triggers before method validation or file searching.

    - Ensures that redirected routes do not trigger 404/405 errors unnecessarily.

**Response Headers**: Automatically populates the `Location` header and sets the appropriate status message based on the code provided in the config.

Closes #11 