### PR TITLE
Feature/20 multiple ports and server blocks

### DIFF
--- a/config/default.conf
+++ b/config/default.conf
@@ -15,6 +15,7 @@ server {
         autoindex on;
     }
 
+
     location /uploads {
         root www/uploads;
         methods GET POST DELETE;
@@ -42,5 +43,23 @@ server {
         root cgi-bin/shell;
         methods GET POST;
         cgi_extension .sh;
+    }
+}
+
+server {
+    listen 8080;
+    server_name site2.local;
+
+    client_max_body_size 1M;
+    client_timeout 60;
+
+    error_page 404 /www/error/404.html;
+    error_page 500 /www/error/500.html;
+
+    location / {
+        root www;
+        index index2.html;
+        methods GET;
+        autoindex on;
     }
 }

--- a/includes/Cluster.hpp
+++ b/includes/Cluster.hpp
@@ -74,6 +74,7 @@ class Cluster {
 		void closeConnection(int fd);
 		void updatePollEvents(int fd, short events);
 		bool handleClientResponse(int fd);
+		int resolveServerConfig(int port, const std::string& host);
 
 		// Utils for pollfds management and metadata
 		void addFD(int fd, FDType type, int client_ref, int timeout);

--- a/includes/Request.hpp
+++ b/includes/Request.hpp
@@ -45,6 +45,7 @@ public:
 	std::string	getHttpVersion() const;
 	std::string	getBody() const;
 	std::map<std::string, std::string>	getHeaders() const;
+	std::string	getHeaders(const std::string& key) const;
 	State	getState() const;
 	int		getErrorCode() const;
 

--- a/srcs/core/Cluster.cpp
+++ b/srcs/core/Cluster.cpp
@@ -24,21 +24,17 @@ void	Cluster::setupCluster()
 	_fd_table.clear();
 	_listen_sockets.clear();
 
+	std::set<std::pair<std::string, int>> bound_addresses;
+
 	int error_code = 0;
 	for (const auto& config : _config_data)
 	{
+		std::string host = config.host.empty() ? "0.0.0.0" : config.host;
 		int port = config.port;
-		bool already_open = false;
-		for (const auto& [fd, open_port] : _listen_sockets)
-		{
-			if (port == open_port)
-			{
-				already_open = true;
-				break;
-			}
-		}
-		if (already_open == true)
+
+		if (bound_addresses.count({host, port}))
 			continue;
+
 		int socket_fd = socket(AF_INET, SOCK_STREAM, 0);
 		if (socket_fd < 0)
 		{
@@ -55,7 +51,11 @@ void	Cluster::setupCluster()
 		sockaddr_in address{};
 		address.sin_family = AF_INET;
 		address.sin_port = htons(port);
-		address.sin_addr.s_addr = INADDR_ANY;
+		if (host == "0.0.0.0")
+			address.sin_addr.s_addr = INADDR_ANY;
+		else
+			inet_pton(AF_INET, host.c_str(), &address.sin_addr);
+
 		if (bind(socket_fd, reinterpret_cast<struct sockaddr*>(&address), sizeof(address)) < 0)
 		{
 			error_code = errno;
@@ -71,8 +71,9 @@ void	Cluster::setupCluster()
 
 		addFD(socket_fd, FD_LISTENER, -1, 0);
 		_listen_sockets[socket_fd] = port;
+		bound_addresses.insert({host, port});
 
-		Logger::info("Listening on port " + std::to_string(port) + " (fd: " + std::to_string(socket_fd) + ")");
+		Logger::info("Listening on port " + host + ":" + std::to_string(port) + " (fd: " + std::to_string(socket_fd) + ")");
 		std::cout << "http://localhost:" << port << std::endl;
 	}
 }

--- a/srcs/core/Cluster.cpp
+++ b/srcs/core/Cluster.cpp
@@ -214,6 +214,14 @@ bool Cluster::handleClientRequest(int fd)
 			updatePollEvents(fd, POLLOUT);
 		}
 		else {
+			std::string host = data.request.getHeaders("host");
+			size_t colon = host.find(':');
+			if (colon != std::string::npos)
+				host = host.substr(0, colon);
+
+			int resolved = resolveServerConfig(data.port, host);
+			if (resolved >= 0)
+				data.config_index = resolved;
 			Logger::info("Request " + data.request.getMethod() + " " +
 			data.request.getPath() + " fully recieved [FD " + std::to_string(fd) + "]");
 			data.client_state = STATE_PROCESSING;
@@ -236,6 +244,24 @@ bool Cluster::handleClientRequest(int fd)
 		return true;
 	}
 	return false;
+}
+
+int Cluster::resolveServerConfig(int port, const std::string& host){
+	int default_config = -1;
+
+	for (int idx = 0; idx < static_cast<int>(_config_data.size()); ++idx)
+	{
+		if (_config_data[idx].port != port)
+			continue;
+		if (default_config < 0)
+			default_config = idx;
+		for (const auto& name : _config_data[idx].server_names)
+		{
+			if (name == host)
+				return idx;
+		}
+	}
+	return default_config;
 }
 
 void Cluster::closeConnection(int fd)

--- a/srcs/parser/Request.cpp
+++ b/srcs/parser/Request.cpp
@@ -13,6 +13,13 @@ std::string	Request::getMethod() const {return _method; }
 std::string	Request::getHttpVersion() const {return _http_version; }
 std::string	Request::getPath() const {return _path; }
 std::map<std::string, std::string>	Request::getHeaders() const {return _headers; }
+std::string	Request::getHeaders(const std::string& key) const
+{
+	auto it = _headers.find(key);
+	if (it == _headers.end())
+		return "";
+	return it->second;
+}
 Request::State	Request::getState() const { return _state; }
 int		Request::getErrorCode() const { return _error_code; }
 

--- a/www/index2.html
+++ b/www/index2.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Webserv - HTTP Server</title>
+    <style>
+        body {
+            font-family: Arial, sans-serif;
+            max-width: 800px;
+            margin: 50px auto;
+            padding: 20px;
+            background-color: #f4f4f4;
+        }
+        h1 {
+            color: #333;
+        }
+        .container {
+            background: white;
+            padding: 30px;
+            border-radius: 8px;
+            box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+        }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <h1>🚀 Welcome to Webserv</h1>
+        <p>SERVER2 CHEEEEEEEEEEEEEEEEEEEEEEEK</p>
+        <h2>Features:</h2>
+        <ul>
+            <li>GET, POST, DELETE methods</li>
+            <li>Static file serving</li>
+            <li>CGI support</li>
+            <li>File uploads</li>
+            <li>Custom error pages</li>
+            <li>Multiple server configurations</li>
+        </ul>
+    </div>
+</body>
+</html>


### PR DESCRIPTION
**Implement virtual host routing and multi-port support (#20)**


- Deduplicate listeners by host:port pair (std::set<pair>)
- Bind to specific host via inet_pton (not always INADDR_ANY)
- Add resolveServerConfig() for virtual host routing
- Match Host header against server_names after request parsing
- Fall back to first server block on port when no match found
- Strip port from Host header before matching (localhost:8080 → localhost)

Closes #20