### PR TITLE
CGI Integration — Core Engine

### DIFF
--- a/includes/Cluster.hpp
+++ b/includes/Cluster.hpp
@@ -51,6 +51,8 @@ struct FDMetadata{
 	int				config_index;	// index in _config_data vector
 	int				client_fd;		// Associated client socket (links CGI pipes to specific users)
 
+	std::string		cgi_raw_output;
+
 	Request			request;		// Request obj
 	Response		response;		// Response obj
 	CGIexecutor*	cgi_executor;	// CGI obj arr

--- a/includes/Cluster.hpp
+++ b/includes/Cluster.hpp
@@ -88,6 +88,9 @@ class Cluster {
 		void handleTimeout();
 		void resetConnection(int fd);
 
+		void handleCgiRead(int cgi_fd);
+		void handleCgiEnd(int cgi_fd);
+
 
 		// Response
 		Response generateErrorResponse(int code, int config_index);

--- a/includes/Cluster.hpp
+++ b/includes/Cluster.hpp
@@ -21,6 +21,7 @@
 #include <csignal>
 #include "CGI.hpp"
 
+class CGIexecutor;
 // Default value
 static const size_t			RECV_BUFFER_SIZE		= 4096;
 

--- a/includes/Cluster.hpp
+++ b/includes/Cluster.hpp
@@ -19,6 +19,7 @@
 #include "Logger.hpp"
 #include "Methods.hpp"
 #include <csignal>
+#include "CGI.hpp"
 
 // Default value
 static const size_t			RECV_BUFFER_SIZE		= 4096;
@@ -39,21 +40,22 @@ enum ClientState{
 };
 
 struct FDMetadata{
-	int			fd;				// The file descriptor number
-	FDType		type;			// Purpose of this descriptor (from enum above)
-	ClientState	client_state;	// State of the clients from enum above
+	int				fd;				// The file descriptor number
+	FDType			type;			// Purpose of this descriptor (from enum above)
+	ClientState		client_state;	// State of the clients from enum above
 
-	time_t		last_activity;	// Timestamp of the last I/O operation for timeout logic
-	int			timeout_value;	// Timeout limit
+	time_t			last_activity;	// Timestamp of the last I/O operation for timeout logic
+	int				timeout_value;	// Timeout limit
 
-	int			port;			// Port that client int using
-	int			config_index;	// index in _config_data vector
-	int			client_fd;		// Associated client socket (links CGI pipes to specific users)
+	int				port;			// Port that client int using
+	int				config_index;	// index in _config_data vector
+	int				client_fd;		// Associated client socket (links CGI pipes to specific users)
 
-	Request		request;		// Request obj
-	Response	response;		// Response obj
+	Request			request;		// Request obj
+	Response		response;		// Response obj
+	CGIexecutor*	cgi_executor;	// CGI obj arr
 
-	bool		is_ready_to_close;	// Flag to mark the descriptor for removal from the loop
+	bool			is_ready_to_close;	// Flag to mark the descriptor for removal from the loop
 };
 class Cluster {
 	public:

--- a/includes/Methods.hpp
+++ b/includes/Methods.hpp
@@ -7,25 +7,29 @@
 #include <filesystem>
 #include <unistd.h>
 
+class CGIexecutor;
+
 class RequestHandler{
 	private:
 		static Response			handleGet(const Request &req, const Location &loc);
-		static Response			handlePost(const Request &req, const Location &loc, const ServerConfig &config);
+		static Response			handlePost(const Request &req, const Location &loc);
 		static Response			handleDelete(const Request &req, const Location &loc);
 
-		static Response			handleCgi(const Request &req, const Location &loc, const ServerConfig &config);
+		static CGIexecutor		*handleCgi(const Request &req, const Location &loc, const ServerConfig &config);
+
+		static Response			parseCgiOutput(const std::string& raw_output);
 
 		static std::string		getMimeType(const std::string &path);
 		static bool				isCgiRequest(const Request &req, const Location &loc);
 		static bool				isDirectory(const std::string &path);
 		static bool				fileExists(const std::string &path);
-		static const Location	*findLocation(const std::string &uri, const ServerConfig &config);
 
 		static std::string		generateAutoindex(const std::string &path, const std::string &uri);
 
 		static Response			handleMultipartUpload(const Request &req, const Location &loc, const std::string &content_type, Response &res);
 
-	public:
+		public:
+		static const Location	*findLocation(const std::string &uri, const ServerConfig &config);
 		static Response			handleRequest(Request &req, const ServerConfig &config);
 
 };

--- a/includes/Methods.hpp
+++ b/includes/Methods.hpp
@@ -15,12 +15,9 @@ class RequestHandler{
 		static Response			handlePost(const Request &req, const Location &loc);
 		static Response			handleDelete(const Request &req, const Location &loc);
 
-		static CGIexecutor		*handleCgi(const Request &req, const Location &loc, const ServerConfig &config);
 
-		static Response			parseCgiOutput(const std::string& raw_output);
 
 		static std::string		getMimeType(const std::string &path);
-		static bool				isCgiRequest(const Request &req, const Location &loc);
 		static bool				isDirectory(const std::string &path);
 		static bool				fileExists(const std::string &path);
 
@@ -31,6 +28,9 @@ class RequestHandler{
 		public:
 		static const Location	*findLocation(const std::string &uri, const ServerConfig &config);
 		static Response			handleRequest(Request &req, const ServerConfig &config);
+		static bool				isCgiRequest(const Request &req, const Location &loc);
+		static CGIexecutor		*handleCgi(const Request &req, const Location &loc, const ServerConfig &config);
+		static Response			parseCgiOutput(const std::string& raw_output);
 
 };
 

--- a/includes/Methods.hpp
+++ b/includes/Methods.hpp
@@ -2,6 +2,7 @@
 
 #include "Response.hpp"
 #include "Request.hpp"
+#include "CGI.hpp"
 #include "utils.hpp"
 #include <filesystem>
 #include <unistd.h>
@@ -9,10 +10,13 @@
 class RequestHandler{
 	private:
 		static Response			handleGet(const Request &req, const Location &loc);
-		static Response			handlePost(const Request &req, const Location &loc);
+		static Response			handlePost(const Request &req, const Location &loc, const ServerConfig &config);
 		static Response			handleDelete(const Request &req, const Location &loc);
 
+		static Response			handleCgi(const Request &req, const Location &loc, const ServerConfig &config);
+
 		static std::string		getMimeType(const std::string &path);
+		static bool				isCgiRequest(const Request &req, const Location &loc);
 		static bool				isDirectory(const std::string &path);
 		static bool				fileExists(const std::string &path);
 		static const Location	*findLocation(const std::string &uri, const ServerConfig &config);

--- a/srcs/core/Cluster.cpp
+++ b/srcs/core/Cluster.cpp
@@ -147,13 +147,12 @@ void	Cluster::run()
 
 
 			if (revents & POLLHUP){
-				if (_fd_table.find(fd) != _fd_table.end())
-				{
-					closeConnection(fd);
-				}
-				else
-				{
-					closeConnection(fd);
+				auto it_hup = _fd_table.find(fd);
+				if (it_hup != _fd_table.end()){
+					if (it_hup->second.type == FD_CGI_OUT)
+						handleCgiEnd(fd);
+					else
+						closeConnection(fd);
 				}
 				continue;
 			}
@@ -315,16 +314,52 @@ int Cluster::resolveServerConfig(int port, const std::string& host){
 void Cluster::closeConnection(int fd)
 {
 	auto it = _fd_table.find(fd);
-	if (it != _fd_table.end())
+	if (it == _fd_table.end())
+		return;
+
+	if (it->second.type == FD_CGI_OUT)
+	{
+		// CGI timed out: clean up executor and send 504 to client
+		int client_fd = it->second.client_fd;
+		removeFD(fd);
+		if (_fd_table.count(client_fd))
+		{
+			FDMetadata& cl = _fd_table.at(client_fd);
+			if (cl.cgi_executor)
+			{
+				delete cl.cgi_executor;
+				cl.cgi_executor = nullptr;
+			}
+			cl.response = generateErrorResponse(504, cl.config_index);
+			cl.response.prepare();
+			cl.client_state = STATE_WRITING;
+			updatePollEvents(client_fd, POLLOUT);
+		}
+	}
+	else
 	{
 		if (it->second.type == FD_CLIENT && it->second.cgi_executor != nullptr)
 		{
+			// Client disconnected while CGI running: kill child process
 			Logger::info("Cleaning up CGI executor for client FD " + std::to_string(fd));
+			it->second.cgi_executor->killChildProcess();
 			delete it->second.cgi_executor;
 			it->second.cgi_executor = nullptr;
+			// Find and remove the orphaned pipe fd (collect first, then remove)
+			int orphan_pipe = -1;
+			for (const auto& [pfd, meta] : _fd_table)
+			{
+				if (meta.type == FD_CGI_OUT && meta.client_fd == fd)
+				{
+					orphan_pipe = pfd;
+					break;
+				}
+			}
+			if (orphan_pipe >= 0)
+				removeFD(orphan_pipe);
 		}
+		removeFD(fd);
 	}
-	removeFD(fd);
 	Logger::info("[Cluster] Connection closed on [FD " + std::to_string(fd) + "]");
 }
 

--- a/srcs/core/Cluster.cpp
+++ b/srcs/core/Cluster.cpp
@@ -529,7 +529,7 @@ void Cluster::handleCgiEnd(int cgi_fd)
 	{
 		FDMetadata& client_data = _fd_table.at(client_fd);
 
-		client_data.response = RequestHandler::parseCgiOutput(client_data.cgi_raw_output);
+		client_data.response = RequestHandler::parseCgiOutput(cgi_data.cgi_raw_output);
 		client_data.response.prepare();
 
 		client_data.client_state = STATE_WRITING;

--- a/srcs/core/Cluster.cpp
+++ b/srcs/core/Cluster.cpp
@@ -162,9 +162,9 @@ void Cluster::acceptNewConnection(int listen_fd)
 	}
 	int port = _listen_sockets.at(listen_fd);
 
-	int timeout = DEFAULT_CLIENT_TIMEOUT;
+	int timeout = 0;
 	int config_index = -1;
-	unsigned long max_body = DEFAULT_MAX_BODY_SIZE;
+	unsigned long max_body = 0;
 
 	for (int idx = 0; idx < static_cast<int>(_config_data.size()); ++idx){
 		if (_config_data[idx].port == port){

--- a/srcs/core/Cluster.cpp
+++ b/srcs/core/Cluster.cpp
@@ -228,13 +228,40 @@ bool Cluster::handleClientRequest(int fd)
 			const Location* loc = RequestHandler::findLocation(data.request.getPath(), config);
 
 			Logger::info("Request " + data.request.getMethod() + " " +
-			data.request.getPath() + " fully recieved [FD " + std::to_string(fd) + "]");
-			data.client_state = STATE_PROCESSING;
-			// TO DO: Handle error pages;
-			data.response = RequestHandler::handleRequest(data.request, _config_data[data.config_index]);
-			data.response.prepare();
-			data.client_state = STATE_WRITING;
-			updatePollEvents(fd, POLLOUT);
+						data.request.getPath() + " fully received [FD " + std::to_string(fd) + "]");
+			if (loc && RequestHandler::isCgiRequest(data.request, *loc))
+			{
+				Logger::info("Launching CGI for FD " + std::to_string(fd));
+				data.cgi_executor = RequestHandler::handleCgi(data.request, *loc, config);
+
+				if (!data.cgi_executor || data.cgi_executor->hasError())
+				{
+					data.response = generateErrorResponse(500, data.config_index);
+					data.response.prepare();
+					data.client_state = STATE_WRITING;
+					updatePollEvents(fd, POLLOUT);
+					if (data.cgi_executor)
+					{
+						delete data.cgi_executor;
+						data.cgi_executor = nullptr;
+					}
+				}
+				else
+				{
+					data.client_state = STATE_PROCESSING;
+					int pipe_out = data.cgi_executor->getOutputFd();
+					addFD(pipe_out, FD_CGI_OUT, fd, config.client_timeout);
+					updatePollEvents(fd, 0);
+				}
+			}
+			else
+			{
+				data.client_state = STATE_PROCESSING;
+				data.response = RequestHandler::handleRequest(data.request, _config_data[data.config_index]);
+				data.response.prepare();
+				data.client_state = STATE_WRITING;
+				updatePollEvents(fd, POLLOUT);
+			}
 		}
 		return false;
 	}

--- a/srcs/core/Cluster.cpp
+++ b/srcs/core/Cluster.cpp
@@ -116,12 +116,20 @@ void	Cluster::run()
 				if (it == _fd_table.end())
 					continue;
 
-				if (it->second.type == FD_LISTENER){
+				if (it->second.type == FD_LISTENER)
+				{
 					acceptNewConnection(fd);
-				} else if (it->second.type == FD_CLIENT){
+				}
+				else if (it->second.type == FD_CLIENT)
+				{
 					if (handleClientRequest(fd))
 						continue;
 				}
+				else if (it->second.type == FD_CGI_OUT)
+				{
+					handleCgiRead(fd);
+				}
+
 			}
 
 			// WRITABLE
@@ -130,7 +138,8 @@ void	Cluster::run()
 				if (it == _fd_table.end())
 					continue;
 
-				if (it->second.type == FD_CLIENT){
+				if (it->second.type == FD_CLIENT)
+				{
 					if (handleClientResponse(fd))
 						continue;
 				}
@@ -139,7 +148,14 @@ void	Cluster::run()
 
 			if (revents & POLLHUP){
 				if (_fd_table.find(fd) != _fd_table.end())
+				{
 					closeConnection(fd);
+				}
+				else
+				{
+					closeConnection(fd);
+				}
+				continue;
 			}
 		}
 	}
@@ -298,6 +314,16 @@ int Cluster::resolveServerConfig(int port, const std::string& host){
 
 void Cluster::closeConnection(int fd)
 {
+	auto it = _fd_table.find(fd);
+	if (it != _fd_table.end())
+	{
+		if (it->second.type == FD_CLIENT && it->second.cgi_executor != nullptr)
+		{
+			Logger::info("Cleaning up CGI executor for client FD " + std::to_string(fd));
+			delete it->second.cgi_executor;
+			it->second.cgi_executor = nullptr;
+		}
+	}
 	removeFD(fd);
 	Logger::info("[Cluster] Connection closed on [FD " + std::to_string(fd) + "]");
 }
@@ -409,9 +435,10 @@ void Cluster::removeFD(int fd)
 			break;
 		}
 	}
+	if (fd >= 0)
+		close(fd);
 	_fd_table.erase(fd);
 
-	close(fd);
 }
 
 void Cluster::updateActivity(int fd)

--- a/srcs/core/Cluster.cpp
+++ b/srcs/core/Cluster.cpp
@@ -363,6 +363,7 @@ void Cluster::addFD(int fd, FDType type, int client_ref, int timeout)
 	metadata.last_activity = time(NULL);
 	metadata.timeout_value = timeout;
 	metadata.is_ready_to_close = false;
+	metadata.cgi_executor = nullptr;
 	metadata.port = -1;
 	metadata.config_index = -1;
 

--- a/srcs/core/Cluster.cpp
+++ b/srcs/core/Cluster.cpp
@@ -223,6 +223,10 @@ bool Cluster::handleClientRequest(int fd)
 			int resolved = resolveServerConfig(data.port, host);
 			if (resolved >= 0)
 				data.config_index = resolved;
+
+			const ServerConfig& config = _config_data[data.config_index];
+			const Location* loc = RequestHandler::findLocation(data.request.getPath(), config);
+
 			Logger::info("Request " + data.request.getMethod() + " " +
 			data.request.getPath() + " fully recieved [FD " + std::to_string(fd) + "]");
 			data.client_state = STATE_PROCESSING;

--- a/srcs/core/Cluster.cpp
+++ b/srcs/core/Cluster.cpp
@@ -463,6 +463,36 @@ Response Cluster::generateErrorResponse(int code, int config_index) {
 	return res;
 }
 
+void	Cluster::handleCgiRead(int cgi_fd)
+{
+	FDMetadata& data = _fd_table.at(cgi_fd);
+
+	if (_fd_table.find(data.client_fd) == _fd_table.end())
+	{
+		removeFD(cgi_fd);
+		return;
+	}
+
+	char buffer[RECV_BUFFER_SIZE];
+	ssize_t bytes = read(cgi_fd, buffer, sizeof(buffer));
+
+	if (bytes > 0)
+	{
+		data.cgi_raw_output.append(buffer, bytes);
+		updateActivity(cgi_fd);
+		updateActivity(data.client_fd);
+	}
+	else if (bytes == 0)
+	{
+		handleCgiEnd(cgi_fd);
+	}
+	else
+	{
+		Logger::error("CGI read error on pipe " + std::to_string(cgi_fd));
+		handleCgiEnd(cgi_fd);
+	}
+}
+
 void	Cluster::requestShutdown() {
 	_shutdown = true;
 }

--- a/srcs/core/Cluster.cpp
+++ b/srcs/core/Cluster.cpp
@@ -465,9 +465,9 @@ Response Cluster::generateErrorResponse(int code, int config_index) {
 
 void	Cluster::handleCgiRead(int cgi_fd)
 {
-	FDMetadata& data = _fd_table.at(cgi_fd);
+	FDMetadata& cgi_data = _fd_table.at(cgi_fd);
 
-	if (_fd_table.find(data.client_fd) == _fd_table.end())
+	if (_fd_table.find(cgi_data.client_fd) == _fd_table.end())
 	{
 		removeFD(cgi_fd);
 		return;
@@ -478,9 +478,9 @@ void	Cluster::handleCgiRead(int cgi_fd)
 
 	if (bytes > 0)
 	{
-		data.cgi_raw_output.append(buffer, bytes);
+		cgi_data.cgi_raw_output.append(buffer, bytes);
 		updateActivity(cgi_fd);
-		updateActivity(data.client_fd);
+		updateActivity(cgi_data.client_fd);
 	}
 	else if (bytes == 0)
 	{
@@ -491,6 +491,31 @@ void	Cluster::handleCgiRead(int cgi_fd)
 		Logger::error("CGI read error on pipe " + std::to_string(cgi_fd));
 		handleCgiEnd(cgi_fd);
 	}
+}
+
+void Cluster::handleCgiEnd(int cgi_fd)
+{
+	FDMetadata& cgi_data = _fd_table.at(cgi_fd);
+	int client_fd = cgi_data.client_fd;
+
+	if (_fd_table.find(client_fd) != _fd_table.end())
+	{
+		FDMetadata& client_data = _fd_table.at(client_fd);
+
+		client_data.response = RequestHandler::parseCgiOutput(client_data.cgi_raw_output);
+		client_data.response.prepare();
+
+		client_data.client_state = STATE_WRITING;
+		updatePollEvents(client_fd, POLLOUT);
+
+		if (client_data.cgi_executor)
+		{
+			delete client_data.cgi_executor;
+			client_data.cgi_executor = nullptr;
+		}
+	}
+	removeFD(cgi_fd);
+	Logger::info("CGI processing complete for client FD " + std::to_string(client_fd));
 }
 
 void	Cluster::requestShutdown() {

--- a/srcs/logic/Methods.cpp
+++ b/srcs/logic/Methods.cpp
@@ -158,7 +158,7 @@ Response RequestHandler::handleRequest(Request &req, const ServerConfig &config)
 	if (req.getMethod() == "GET")
 		res = handleGet(req, *loc);
 	else if (req.getMethod() == "POST")
-		res = handlePost(req, *loc, config);
+		res = handlePost(req, *loc);
 	else if (req.getMethod() == "DELETE")
 		res = handleDelete(req, *loc);
 	else
@@ -232,9 +232,7 @@ Response RequestHandler::handleMultipartUpload(const Request &req, const Locatio
 	return res;
 }
 
-Response RequestHandler::handleCgi(const Request &req, const Location &loc, const ServerConfig &config){
-	Response res;
-
+CGIexecutor *RequestHandler::handleCgi(const Request &req, const Location &loc, const ServerConfig &config) {
 	std::string full_path = req.getPath();
 	size_t query_pos = full_path.find('?');
 	std::string script_uri = (query_pos == std::string::npos) ? full_path : full_path.substr(0, query_pos);
@@ -242,83 +240,71 @@ Response RequestHandler::handleCgi(const Request &req, const Location &loc, cons
 
 	std::string script_path = loc.root + script_uri.substr(loc.path.length());
 
-	CGIexecutor *executor = runCGI(script_path, query_string, req.getBody(), config);
-	if (!executor){
-		res.setStatusCode(500);
-		return res;
-	}
+	CGIconfig cgi_config(script_path, query_string, req.getBody(), config);
+	CGIexecutor *executor = new CGIexecutor(cgi_config);
 
 	std::map<std::string, std::string> req_headers = req.getHeaders();
-	for (std::map<std::string, std::string>::const_iterator it = req_headers.begin(); it != req_headers.end(); ++it)
+	for (std::map<std::string, std::string>::const_iterator it = req_headers.begin(); it != req_headers.end(); ++it){
 		executor->setHttpHeader(it->first, it->second);
-
-	while (executor->isComplete() == 0){
-		if (executor->checkTimeout()){
-			res.setStatusCode(504);
-			delete executor;
-			return res;
-		}
-		if (executor->readOutput() < 0)
-			break;
 	}
 
-	if (executor->hasError())
-		res.setStatusCode(502);
-	else{
-		std::string raw_output = executor->getOutput();
-		size_t sep = raw_output.find("\r\n\r\n");
-		size_t sep_len = 4;
+	if (executor->start() != 0) {
+		delete executor;
+		return NULL;
+	}
 
-		if (sep == std::string::npos){
-			sep = raw_output.find("\n\n");
-			sep_len = 2;
-		}
+	return executor;
+}
 
-		if (sep != std::string::npos) {
-			std::string headers_part = raw_output.substr(0, sep);
-			std::string body_part = raw_output.substr(sep + sep_len);
+Response RequestHandler::parseCgiOutput(const std::string& raw_output){
+	Response res;
+	size_t sep = raw_output.find("\r\n\r\n");
+	size_t sep_len = 4;
 
-			std::istringstream stream(headers_part);
-			std::string header_line;
-			while (std::getline(stream, header_line)){
-				if (!header_line.empty() && header_line.back() == '\r')
-					header_line.pop_back();
+	if (sep == std::string::npos){
+		sep = raw_output.find("\n\n");
+		sep_len = 2;
+	}
 
-				size_t colon = header_line.find(':');
-				if (colon != std::string::npos){
-					std::string key = header_line.substr(0, colon);
-					std::string val = header_line.substr(colon + 1);
-					val.erase(0, val.find_first_not_of(" "));
+	if (sep != std::string::npos){
+		std::string headers_part = raw_output.substr(0, sep);
+		std::string body_part = raw_output.substr(sep + sep_len);
 
-					if (key == "Status")
-						res.setStatusCode(std::atoi(val.c_str()));
-					else
-						res.addHeader(key, val);
-				}
+		std::istringstream stream(headers_part);
+		std::string header_line;
+		while (std::getline(stream, header_line)){
+			if (!header_line.empty() && header_line.back() == '\r')
+				header_line.pop_back();
+
+			size_t colon = header_line.find(':');
+			if (colon != std::string::npos){
+				std::string key = header_line.substr(0, colon);
+				std::string val = header_line.substr(colon + 1);
+				val.erase(0, val.find_first_not_of(" "));
+
+				if (key == "Status")
+					res.setStatusCode(std::atoi(val.c_str()));
+				else
+					res.addHeader(key, val);
 			}
-			res.setStatusCode(res.getStatusCode() ? res.getStatusCode() : 200);
-			res.setBody(body_part);
 		}
-		else{
-			res.setStatusCode(502);
-			res.setBody("CGI Error: Invalid output format (missing header separator)");
-		}
+		res.setStatusCode(res.getStatusCode() ? res.getStatusCode() : 200);
+		res.setBody(body_part);
 	}
-
-	delete executor;
+	else{
+		res.setStatusCode(502);
+		res.setBody("CGI Error: Missing header separator");
+	}
 	return res;
 }
 
-Response RequestHandler::handlePost(const Request &req, const Location &loc, const ServerConfig &config){
+Response RequestHandler::handlePost(const Request &req, const Location &loc){
 	Response res;
 
 	if (!loc.upload_dir.has_value()){
 		res.setStatusCode(403);
 		return res;
 	}
-
-	if (isCgiRequest(req, loc))
-		return handleCgi(req, loc, config);
 
 	std::string content_type = "";
 	std::map<std::string, std::string> headers = req.getHeaders();

--- a/srcs/logic/Methods.cpp
+++ b/srcs/logic/Methods.cpp
@@ -33,6 +33,19 @@ std::string RequestHandler::getMimeType(const std::string &path){
 	return "application/octet-stream";
 }
 
+bool RequestHandler::isCgiRequest(const Request &req, const Location &loc){
+	if (!loc.cgi_ext.has_value())
+		return false;
+	std::string path = req.getPath();
+	size_t query_pos = path.find('?');
+	std::string clean_path = (query_pos == std::string::npos) ? path : path.substr(0, query_pos);
+
+	size_t dot_pos = clean_path.find_last_of(".");
+	if (dot_pos == std::string::npos)
+		return false;
+	return clean_path.substr(dot_pos) == loc.cgi_ext.value();
+}
+
 const Location *RequestHandler::findLocation(const std::string &uri, const ServerConfig &config){
 	const Location* best_match = nullptr;
 	size_t max_len = 0;
@@ -113,7 +126,7 @@ Response RequestHandler::handleRequest(Request &req, const ServerConfig &config)
 	if (!loc){
 		res.setStatusCode(404);
 		return res;
-	}	
+	}
 
 	if (!loc->redirection.second.empty()){
 		int code = loc->redirection.first;
@@ -145,7 +158,7 @@ Response RequestHandler::handleRequest(Request &req, const ServerConfig &config)
 	if (req.getMethod() == "GET")
 		res = handleGet(req, *loc);
 	else if (req.getMethod() == "POST")
-		res = handlePost(req, *loc);
+		res = handlePost(req, *loc, config);
 	else if (req.getMethod() == "DELETE")
 		res = handleDelete(req, *loc);
 	else
@@ -219,7 +232,84 @@ Response RequestHandler::handleMultipartUpload(const Request &req, const Locatio
 	return res;
 }
 
-Response RequestHandler::handlePost(const Request &req, const Location &loc){
+Response RequestHandler::handleCgi(const Request &req, const Location &loc, const ServerConfig &config){
+	Response res;
+
+	std::string full_path = req.getPath();
+	size_t query_pos = full_path.find('?');
+	std::string script_uri = (query_pos == std::string::npos) ? full_path : full_path.substr(0, query_pos);
+	std::string query_string = (query_pos == std::string::npos) ? "" : full_path.substr(query_pos + 1);
+
+	std::string script_path = loc.root + script_uri.substr(loc.path.length());
+
+	CGIexecutor *executor = runCGI(script_path, query_string, req.getBody(), config);
+	if (!executor){
+		res.setStatusCode(500);
+		return res;
+	}
+
+	std::map<std::string, std::string> req_headers = req.getHeaders();
+	for (std::map<std::string, std::string>::const_iterator it = req_headers.begin(); it != req_headers.end(); ++it)
+		executor->setHttpHeader(it->first, it->second);
+
+	while (executor->isComplete() == 0){
+		if (executor->checkTimeout()){
+			res.setStatusCode(504);
+			delete executor;
+			return res;
+		}
+		if (executor->readOutput() < 0)
+			break;
+	}
+
+	if (executor->hasError())
+		res.setStatusCode(502);
+	else{
+		std::string raw_output = executor->getOutput();
+		size_t sep = raw_output.find("\r\n\r\n");
+		size_t sep_len = 4;
+
+		if (sep == std::string::npos){
+			sep = raw_output.find("\n\n");
+			sep_len = 2;
+		}
+
+		if (sep != std::string::npos) {
+			std::string headers_part = raw_output.substr(0, sep);
+			std::string body_part = raw_output.substr(sep + sep_len);
+
+			std::istringstream stream(headers_part);
+			std::string header_line;
+			while (std::getline(stream, header_line)){
+				if (!header_line.empty() && header_line.back() == '\r')
+					header_line.pop_back();
+
+					size_t colon = header_line.find(':');
+				if (colon != std::string::npos){
+					std::string key = header_line.substr(0, colon);
+					std::string val = header_line.substr(colon + 1);
+					val.erase(0, val.find_first_not_of(" "));
+
+					if (key == "Status")
+						res.setStatusCode(std::atoi(val.c_str()));
+					else
+						res.addHeader(key, val);
+				}
+			}
+			res.setStatusCode(res.getStatusCode() ? res.getStatusCode() : 200);
+			res.setBody(body_part);
+		}
+		else{
+			res.setStatusCode(502);
+			res.setBody("CGI Error: Invalid output format (missing header separator)");
+		}
+	}
+
+	delete executor;
+	return res;
+}
+
+Response RequestHandler::handlePost(const Request &req, const Location &loc, const ServerConfig &config){
 	Response res;
 
 	if (!loc.upload_dir.has_value()){
@@ -227,9 +317,8 @@ Response RequestHandler::handlePost(const Request &req, const Location &loc){
 		return res;
 	}
 
-	if (loc.cgi_path.has_value() && !loc.cgi_ext.value_or("").empty()){
-		// return handleCgi(req, loc); or smth like that
-	}
+	if (isCgiRequest(req, loc))
+		return handleCgi(req, loc, config);
 
 	std::string content_type = "";
 	std::map<std::string, std::string> headers = req.getHeaders();

--- a/srcs/logic/Methods.cpp
+++ b/srcs/logic/Methods.cpp
@@ -284,7 +284,7 @@ Response RequestHandler::handleCgi(const Request &req, const Location &loc, cons
 				if (!header_line.empty() && header_line.back() == '\r')
 					header_line.pop_back();
 
-					size_t colon = header_line.find(':');
+				size_t colon = header_line.find(':');
 				if (colon != std::string::npos){
 					std::string key = header_line.substr(0, colon);
 					std::string val = header_line.substr(colon + 1);


### PR DESCRIPTION
**Overview**
Integrates CGI execution lifecycle into the Cluster event loop. The engine now detects CGI requests, launches child processes, reads their output non-blocking through [poll()](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html), and delivers the response to the client — handling all error and timeout paths cleanly.

- [FDMetadata](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html): added [CGIexecutor* cgi_executor](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) — owned by the [FD_CLIENT](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) entry, nullptr by default
- [FDMetadata](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html): added std::string cgi_raw_output — output buffer stored in the [FD_CGI_OUT](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) entry
- [Cluster](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html): declared [handleCgiRead(int)](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) and [handleCgiEnd(int)](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) private methods
- [Cluster.cpp](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
- [run()](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html): [POLLIN](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) on [FD_CGI_OUT](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) routes to [handleCgiRead](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html); [POLLHUP](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) on [FD_CGI_OUT](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) routes to [handleCgiEnd](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) instead of [closeConnection](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html), ensuring the buffer is drained before the pipe is closed
- [handleClientRequest()](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html): after request is parsed, calls [findLocation](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) → [isCgiRequest](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) → [handleCgi](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html); on success registers pipe via [addFD(FD_CGI_OUT)](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) and suspends client polling ([events = 0](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html)); on failure sends 500 immediately
- [handleCgiRead()](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html): non-blocking drain of CGI stdout pipe into cgi_raw_output; EOF triggers [handleCgiEnd](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
- [handleCgiEnd()](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html): calls [parseCgiOutput](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) → builds [Response](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) → enables [POLLOUT](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) on client; deletes cgi_executor
- [closeConnection()](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html):
- [FD_CGI_OUT](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) path (timeout): deletes executor, sends 504 to the waiting client
- [FD_CLIENT](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) path with active CGI: calls [killChildProcess()](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html), deletes executor, finds and removes orphan pipe fd (collected before removal to avoid iterator invalidation)

Closed Issues

- #CGI-02 — cgi_executor field in [FDMetadata](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
- #CGI-03 — CGI pipe reading via [poll()](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
- #CGI-05 — CGI launch from [handleClientRequest](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
- #CGI-06 — CGI cleanup on client disconnect
- [#CGI-timeout](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) — 504 response on CGI timeout
- [#CGI-POLLHUP](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) — correct [POLLHUP](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) routing for [FD_CGI_OUT](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html)

Closes #46 #47 #49 #50  #51 #54